### PR TITLE
Private provisioning profile reference removed

### DIFF
--- a/Xamarin-Tesseract-OCR-iOS/Tesseract.iOS-Sample/Tesseract.iOS-Sample.csproj
+++ b/Xamarin-Tesseract-OCR-iOS/Tesseract.iOS-Sample/Tesseract.iOS-Sample.csproj
@@ -59,7 +59,6 @@
     </MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchFastDev>true</MtouchFastDev>
-    <CodesignProvision>d18e6e6f-633d-46f3-917a-0d0ca14140ea</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>


### PR DESCRIPTION
This way, the toolchain will pick a profile automatically, rather than produce an error when encountering the unknown provisioning profile.